### PR TITLE
pyproject.toml: explicitly set build-backend

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
 requires = ['setuptools']
+build-backend = "setuptools.build_meta"
 
 
 [project]


### PR DESCRIPTION
I am currently in the progress of bumping Tex Live in Gentoo and this change is required for the bump.

Prior to this change, pyproject.toml would not set an build-backend, while the project also has no setup.py.

According to some experts from Gentoo's Python project, this is a violation of PEP 517, which states

> If the pyproject.toml file is absent, or the build-backend key is missing, the source tree is not using this specification, and tools should revert to the legacy behaviour of running setup.py (either directly, or by implicitly invoking the setuptools.build_meta:__legacy__ backend). 

However, the project has no setup.py to invoke, hence Gentoo's infrastructor for building Python packages fails without the build-backend key being set.